### PR TITLE
feat: add moonshot provider

### DIFF
--- a/.github/workflows/infer.yml
+++ b/.github/workflows/infer.yml
@@ -62,3 +62,4 @@ jobs:
           cohere-api-key: ${{ secrets.COHERE_API_KEY }}
           ollama-api-key: ${{ secrets.OLLAMA_API_KEY }}
           ollama-cloud-api-key: ${{ secrets.OLLAMA_CLOUD_API_KEY }}
+          moonshot-api-key: ${{ secrets.MOONSHOT_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A GitHub Action that automatically runs the
 [Infer CLI](https://github.com/inference-gateway/cli) agent on GitHub issues.
 The agent can analyze issues, provide solutions, and post results as comments
 using various AI providers (Anthropic, OpenAI, Google, Ollama, Ollama Cloud,
-Groq and more).
+Groq, Moonshot and more).
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![GitHub release](https://img.shields.io/github/v/release/inference-gateway/infer-action)](https://github.com/inference-gateway/infer-action/releases)
@@ -126,6 +126,7 @@ The model parameter accepts any valid model identifier in the format `provider/m
 - `google/gemini-pro`
 - `deepseek/deepseek-v4-flash`
 - `ollama_cloud/qwen3-coder:480b`
+- `moonshot/kimi-k2`
 
 The model specified in the workflow configuration serves as the default when no `/model` parameter is provided.
 
@@ -409,6 +410,7 @@ permissions:
 | `cohere-api-key`                 | Cohere API key                                                                                      | No\*     | -          |
 | `ollama-api-key`                 | Ollama API key                                                                                      | No\*     | -          |
 | `ollama-cloud-api-key`           | Ollama Cloud API key                                                                                | No\*     | -          |
+| `moonshot-api-key`               | Moonshot API key                                                                                    | No\*     | -          |
 | `max-turns`                      | Maximum agent iterations                                                                            | No       | `50`       |
 | `custom-instructions`            | Additional instructions appended to default behavior                                                | No       | `''`       |
 | `skills`                         | Newline-separated list of skills installed via `infer skills install`. Auto-enables skills.         | No       | `''`       |
@@ -436,6 +438,7 @@ permissions:
 - **Anthropic**: `anthropic/claude-sonnet-4`, `anthropic/claude-opus-4`, etc.
 - **OpenAI**: `openai/gpt-4`, `openai/gpt-4-turbo`, `openai/gpt-3.5-turbo`
 - **Google**: `google/gemini-pro`, `google/gemini-ultra`
+- **Moonshot**: `moonshot/kimi-k2`, `moonshot/kimi-k2-thinking`, `moonshot/moonshot-v1-128k`
 
 ## Security Best Practices
 

--- a/action.yml
+++ b/action.yml
@@ -65,6 +65,10 @@ inputs:
     description: "Ollama Cloud API key (required if using Ollama Cloud)"
     required: false
 
+  moonshot-api-key:
+    description: "Moonshot API key (required if using Moonshot models)"
+    required: false
+
   max-turns:
     description: "Maximum number of agent iterations (default: 50)"
     required: false
@@ -409,6 +413,7 @@ runs:
         CLOUDFLARE_API_KEY: ${{ inputs.cloudflare-api-key }}
         OLLAMA_API_KEY: ${{ inputs.ollama-api-key }}
         OLLAMA_CLOUD_API_KEY: ${{ inputs.ollama-cloud-api-key }}
+        MOONSHOT_API_KEY: ${{ inputs.moonshot-api-key }}
         # Runner config
         GITHUB_TOKEN: ${{ inputs.github-token }}
         INFER_AGENT_MODEL: ${{ steps.check-trigger.outputs.model_override || inputs.model }}


### PR DESCRIPTION
## Summary

Adds the **Moonshot** (Kimi) provider to the action. Moonshot is already implemented in both the Inference Gateway and the `infer` CLI (cli#373, present in the pinned `v0.115.0`), but `infer-action` was missing the per-provider key wiring - so users couldn't supply a `MOONSHOT_API_KEY` or run a `moonshot/...` model through the action.

Purely additive, following the exact pattern every other provider already uses. No `src/`/`dist/` changes (provider routing is fully delegated to the CLI) and no CLI version bump.

## Changes

- **`action.yml`** - new `moonshot-api-key` input + `MOONSHOT_API_KEY` env mapping in the agent step.
- **`README.md`** - `moonshot-api-key` row in the inputs table, a `**Moonshot**` entry under Supported Models, a `moonshot/kimi-k2` example in the model-format list, and Moonshot in the overview prose.
- **`.github/workflows/infer.yml`** - `moonshot-api-key` added to the dogfood workflow.

Conventions verified org-wide (gateway `openapi.yaml`/`constants.go`, CLI `pricing.go`/`model_context.go`, docs): env var `MOONSHOT_API_KEY`, prefix `moonshot/`, models `moonshot/kimi-k2`, `moonshot/kimi-k2-thinking`, `moonshot/moonshot-v1-128k`.

## Acceptance criteria (#27)

- [x] Moonshot provider is added
- [x] It's documented (README)
- [x] Follow-up to extensive docs - `inference-gateway/docs` `github-action.md` was missing the `moonshot-api-key` row; addressed via a companion docs PR + tracking issue (linked below).

## Cross-repo impact

- **`inference-gateway/docs`** - companion PR adds the missing `moonshot-api-key` row to the infer-action inputs table.

## Verification

- `npm run format:check` ✅ · `npm run typecheck` ✅ · `npm test` ✅ (20 passed, 1 skipped) · `dist/` untouched.

## Side-find (tracked separately, not in this PR)

`COHERE_API_KEY` is defined as an input (`action.yml:56`) and used in the workflow but is **never** forwarded in the agent `env` block (`action.yml:402-411`), unlike every other provider — a supplied Cohere key never reaches the CLI. Filed as a separate `fix:` issue.

Closes #27