### PR TITLE
fix: forward COHERE_API_KEY to the agent env

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -411,6 +411,7 @@ runs:
         GROQ_API_KEY: ${{ inputs.groq-api-key }}
         MISTRAL_API_KEY: ${{ inputs.mistral-api-key }}
         CLOUDFLARE_API_KEY: ${{ inputs.cloudflare-api-key }}
+        COHERE_API_KEY: ${{ inputs.cohere-api-key }}
         OLLAMA_API_KEY: ${{ inputs.ollama-api-key }}
         OLLAMA_CLOUD_API_KEY: ${{ inputs.ollama-cloud-api-key }}
         MOONSHOT_API_KEY: ${{ inputs.moonshot-api-key }}


### PR DESCRIPTION
## Summary

`cohere-api-key` is a fully-wired action input — declared in `action.yml`, documented in the README inputs table, and passed through the dogfood workflow — **except** for the one place that matters: it was never mapped into the "Run Infer agent" step's `env:` block alongside the other provider keys (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, …, `MOONSHOT_API_KEY`).

As a result a supplied `cohere-api-key` was silently dropped, so `COHERE_API_KEY` never reached the spawned `infer agent` process and Cohere models failed to authenticate.

## Change

One line added to the agent step's `env:` block in `action.yml`, slotted after `CLOUDFLARE_API_KEY` so the env ordering matches the input declaration order (cloudflare → cohere → ollama):

```yaml
COHERE_API_KEY: ${{ inputs.cohere-api-key }}
```

No other files needed changes — `action.yml` is the action manifest and is not part of the `src/ → dist/` ncc build, so no `dist/` rebuild is required. The change mirrors the existing, working pattern for the other ten providers exactly.

Closes #30