### PR TITLE
feat: show total tool calls and success rate in result footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ jobs:
    - The model that was used
    - Token usage for the run (prompt / completion / total, plus request count)
    - Per-session cost for the run (input / output / total), when the CLI reports pricing
+   - Total tool calls made, with the run's success rate
    - Any failed tool calls (collapsed)
    - The tail of the agent transcript (collapsed)
 
@@ -429,10 +430,12 @@ permissions:
 
 ## Outputs
 
-| Output      | Description                      |
-| ----------- | -------------------------------- |
-| `result`    | Human-readable result message    |
-| `exit-code` | Exit code from the agent command |
+| Output                    | Description                                          |
+| ------------------------- | ---------------------------------------------------- |
+| `result`                  | Human-readable result message                        |
+| `exit-code`               | Exit code from the agent command                     |
+| `failed-tool-calls-count` | Number of failed tool calls detected in agent output |
+| `total-tool-calls-count`  | Total number of tool calls made by the agent         |
 
 ## Supported Models
 

--- a/__tests__/post-results.test.ts
+++ b/__tests__/post-results.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { formatCost, formatMoney } from "../src/post-results.js";
+import {
+  formatCost,
+  formatMoney,
+  formatToolCalls,
+} from "../src/post-results.js";
 
 describe("formatMoney", () => {
   it("renders USD with sub-cent precision", () => {
@@ -38,6 +42,43 @@ describe("formatCost", () => {
   it("defaults a blank currency to USD", () => {
     expect(formatCost({ input: 1, output: 2, total: 3, currency: "" })).toBe(
       "**Cost:** $1.00 in · $2.00 out · $3.00 total",
+    );
+  });
+});
+
+describe("formatToolCalls", () => {
+  it("reports 100% success when nothing failed", () => {
+    expect(formatToolCalls(12, 0)).toBe(
+      "**Tool calls:** 12 total · 100% success rate",
+    );
+  });
+
+  it("rounds the success rate to a whole percent", () => {
+    // 10 of 12 succeeded -> 83.33% -> 83%
+    expect(formatToolCalls(12, 2)).toBe(
+      "**Tool calls:** 12 total · 83% success rate",
+    );
+    // 7 of 8 succeeded -> 87.5% -> 88%
+    expect(formatToolCalls(8, 1)).toBe(
+      "**Tool calls:** 8 total · 88% success rate",
+    );
+  });
+
+  it("reports 0% when every call failed", () => {
+    expect(formatToolCalls(5, 5)).toBe(
+      "**Tool calls:** 5 total · 0% success rate",
+    );
+  });
+
+  it("clamps a failed count larger than the total to 0% (never negative)", () => {
+    expect(formatToolCalls(3, 5)).toBe(
+      "**Tool calls:** 3 total · 0% success rate",
+    );
+  });
+
+  it("groups large totals with thousands separators", () => {
+    expect(formatToolCalls(1234, 0)).toBe(
+      "**Tool calls:** 1,234 total · 100% success rate",
     );
   });
 });

--- a/__tests__/usage.test.ts
+++ b/__tests__/usage.test.ts
@@ -18,6 +18,7 @@ describe("extractUsage", () => {
       completionTokens: 0,
       totalTokens: 0,
       requests: 0,
+      toolCalls: 0,
     });
   });
 
@@ -49,6 +50,7 @@ describe("extractUsage", () => {
       completionTokens: 300,
       totalTokens: 2800,
       requests: 2,
+      toolCalls: 1,
     });
   });
 
@@ -70,6 +72,7 @@ describe("extractUsage", () => {
       completionTokens: 10,
       totalTokens: 60,
       requests: 1,
+      toolCalls: 0,
     });
   });
 
@@ -86,6 +89,7 @@ describe("extractUsage", () => {
       completionTokens: 12,
       totalTokens: 42,
       requests: 1,
+      toolCalls: 0,
     });
   });
 
@@ -103,6 +107,7 @@ describe("extractUsage", () => {
       completionTokens: 0,
       totalTokens: 0,
       requests: 0,
+      toolCalls: 0,
     });
   });
 
@@ -133,6 +138,7 @@ describe("extractUsage", () => {
       completionTokens: 100,
       totalTokens: 1100,
       requests: 1,
+      toolCalls: 0,
       cost: { input: 0.678, output: 0.0021, total: 0.6801, currency: "USD" },
     });
   });
@@ -156,6 +162,7 @@ describe("extractUsage", () => {
       completionTokens: 10,
       totalTokens: 60,
       requests: 1,
+      toolCalls: 0,
     });
   });
 
@@ -204,6 +211,7 @@ describe("extractUsage", () => {
       completionTokens: 20,
       totalTokens: 220,
       requests: 1,
+      toolCalls: 0,
       cost: { input: 1, output: 2, total: 3, currency: "USD" },
     });
   });
@@ -279,5 +287,87 @@ describe("extractUsage", () => {
       total: 10,
       currency: "EUR",
     });
+  });
+
+  it("counts every tool call summed across assistant messages", async () => {
+    const path = writeFixture([
+      {
+        role: "assistant",
+        content: "",
+        token_usage: {
+          prompt_tokens: 100,
+          completion_tokens: 10,
+          total_tokens: 110,
+        },
+        tool_calls: [
+          { id: "c1", function: { name: "TodoWrite" } },
+          { id: "c2", function: { name: "Read" } },
+        ],
+      },
+      { role: "tool", content: "Result of tool call: {}", tool_call_id: "c1" },
+      { role: "tool", content: "Result of tool call: {}", tool_call_id: "c2" },
+      {
+        role: "assistant",
+        content: "done",
+        token_usage: {
+          prompt_tokens: 150,
+          completion_tokens: 20,
+          total_tokens: 170,
+        },
+        tool_calls: [{ id: "c3", function: { name: "Bash" } }],
+      },
+    ]);
+    expect(await extractUsage(path)).toMatchObject({ toolCalls: 3 });
+  });
+
+  it("counts parallel tool calls within a single message", async () => {
+    const path = writeFixture([
+      {
+        role: "assistant",
+        content: "",
+        token_usage: {
+          prompt_tokens: 100,
+          completion_tokens: 10,
+          total_tokens: 110,
+        },
+        tool_calls: [
+          { id: "a", function: { name: "Read" } },
+          { id: "b", function: { name: "Read" } },
+          { id: "c", function: { name: "Read" } },
+        ],
+      },
+    ]);
+    expect((await extractUsage(path)).toolCalls).toBe(3);
+  });
+
+  it("counts tool calls even when the assistant message has no token_usage", async () => {
+    const path = writeFixture([
+      {
+        role: "assistant",
+        content: "",
+        tool_calls: [{ id: "c1", function: { name: "Grep" } }],
+      },
+    ]);
+    expect(await extractUsage(path)).toEqual({
+      promptTokens: 0,
+      completionTokens: 0,
+      totalTokens: 0,
+      requests: 0,
+      toolCalls: 1,
+    });
+  });
+
+  it("does not count tool calls on non-assistant lines", async () => {
+    const path = writeFixture([
+      { role: "user", content: "do a thing" },
+      { role: "tool", content: "Result of tool call: {}", tool_call_id: "x" },
+      { type: "session_stats", cost: { input: 1, output: 1, total: 2 } },
+      {
+        role: "assistant",
+        content: "",
+        tool_calls: [{ id: "c1", function: { name: "Read" } }],
+      },
+    ]);
+    expect((await extractUsage(path)).toolCalls).toBe(1);
   });
 });

--- a/action.yml
+++ b/action.yml
@@ -264,6 +264,10 @@ outputs:
     description: "Number of failed tool calls detected in agent output"
     value: ${{ steps.post-results.outputs.failed-count }}
 
+  total-tool-calls-count:
+    description: "Total number of tool calls made by the agent"
+    value: ${{ steps.post-results.outputs.total-count }}
+
 runs:
   using: "composite"
   steps:

--- a/dist/post-results/index.js
+++ b/dist/post-results/index.js
@@ -250,8 +250,9 @@ var __webpack_exports__ = {};
 
 // EXPORTS
 __nccwpck_require__.d(__webpack_exports__, {
-  B: () => (/* binding */ formatCost),
-  u: () => (/* binding */ formatMoney)
+  BD: () => (/* binding */ formatCost),
+  up: () => (/* binding */ formatMoney),
+  vZ: () => (/* binding */ formatToolCalls)
 });
 
 ;// CONCATENATED MODULE: external "node:fs"
@@ -4884,6 +4885,11 @@ function escapeRegex(s) {
  * the last such line and surface its cost only when non-zero — pricing-disabled
  * or unpriced runs report zeros, in which case `cost` is left undefined and the
  * footer omits it.
+ *
+ * `toolCalls` is the total number of tool calls the agent made, summed from
+ * every assistant message's `tool_calls[]` (counted independently of token
+ * usage, so calls on a token-less turn still count). It pairs with the footer's
+ * failed-tool-call list to give a success rate.
  */
 async function extractUsage(path) {
     const totals = {
@@ -4891,6 +4897,7 @@ async function extractUsage(path) {
         completionTokens: 0,
         totalTokens: 0,
         requests: 0,
+        toolCalls: 0,
     };
     if (!(0,external_node_fs_namespaceObject.existsSync)(path))
         return totals;
@@ -4915,6 +4922,8 @@ async function extractUsage(path) {
         }
         if (!isAssistantMessage(msg))
             continue;
+        if (msg.tool_calls)
+            totals.toolCalls += msg.tool_calls.length;
         const usage = msg.token_usage;
         if (!usage)
             continue;
@@ -4978,6 +4987,7 @@ async function main() {
         agentOutputTail,
     });
     setOutput("failed-count", String(failures.length));
+    setOutput("total-count", String(usage.toolCalls));
     writeStepSummary(redactor.redact(footer));
     let patched = false;
     if (cookingCommentId > 0) {
@@ -5034,6 +5044,10 @@ function buildFooter(args) {
             lines.push(formatCost(args.usage.cost));
         }
     }
+    if (args.usage.toolCalls > 0) {
+        lines.push("");
+        lines.push(formatToolCalls(args.usage.toolCalls, args.failures.length));
+    }
     lines.push("");
     if (args.failures.length > 0) {
         lines.push(`<details><summary>⚠️ ${args.failures.length} failed tool call(s)</summary>`);
@@ -5062,6 +5076,13 @@ function formatUsage(usage) {
     const fmt = (n) => n.toLocaleString("en-US");
     const reqs = usage.requests === 1 ? "1 request" : `${usage.requests} requests`;
     return `**Tokens:** ${fmt(usage.promptTokens)} in · ${fmt(usage.completionTokens)} out · ${fmt(usage.totalTokens)} total (${reqs})`;
+}
+// `failed` is clamped to `total` so a malformed stream (more failure results than
+// recorded calls) can never produce a negative or >100% success rate.
+function formatToolCalls(total, failed) {
+    const succeeded = Math.max(0, total - failed);
+    const rate = total > 0 ? Math.round((succeeded / total) * 100) : 0;
+    return `**Tool calls:** ${total.toLocaleString("en-US")} total · ${rate}% success rate`;
 }
 function formatCost(cost) {
     const currency = cost.currency || "USD";
@@ -5144,6 +5165,7 @@ if (!process.env["VITEST"]) {
     });
 }
 
-var __webpack_exports__formatCost = __webpack_exports__.B;
-var __webpack_exports__formatMoney = __webpack_exports__.u;
-export { __webpack_exports__formatCost as formatCost, __webpack_exports__formatMoney as formatMoney };
+var __webpack_exports__formatCost = __webpack_exports__.BD;
+var __webpack_exports__formatMoney = __webpack_exports__.up;
+var __webpack_exports__formatToolCalls = __webpack_exports__.vZ;
+export { __webpack_exports__formatCost as formatCost, __webpack_exports__formatMoney as formatMoney, __webpack_exports__formatToolCalls as formatToolCalls };

--- a/src/post-results.ts
+++ b/src/post-results.ts
@@ -55,6 +55,7 @@ async function main(): Promise<number> {
   });
 
   setOutput("failed-count", String(failures.length));
+  setOutput("total-count", String(usage.toolCalls));
   writeStepSummary(redactor.redact(footer));
 
   let patched = false;
@@ -135,6 +136,10 @@ function buildFooter(args: FooterArgs): string {
       lines.push(formatCost(args.usage.cost));
     }
   }
+  if (args.usage.toolCalls > 0) {
+    lines.push("");
+    lines.push(formatToolCalls(args.usage.toolCalls, args.failures.length));
+  }
   lines.push("");
 
   if (args.failures.length > 0) {
@@ -172,6 +177,14 @@ function formatUsage(usage: UsageTotals): string {
   const reqs =
     usage.requests === 1 ? "1 request" : `${usage.requests} requests`;
   return `**Tokens:** ${fmt(usage.promptTokens)} in · ${fmt(usage.completionTokens)} out · ${fmt(usage.totalTokens)} total (${reqs})`;
+}
+
+// `failed` is clamped to `total` so a malformed stream (more failure results than
+// recorded calls) can never produce a negative or >100% success rate.
+export function formatToolCalls(total: number, failed: number): string {
+  const succeeded = Math.max(0, total - failed);
+  const rate = total > 0 ? Math.round((succeeded / total) * 100) : 0;
+  return `**Tool calls:** ${total.toLocaleString("en-US")} total · ${rate}% success rate`;
 }
 
 export function formatCost(cost: CostTotals): string {

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -14,6 +14,7 @@ export interface UsageTotals {
   completionTokens: number;
   totalTokens: number;
   requests: number;
+  toolCalls: number;
   cost?: CostTotals;
 }
 
@@ -30,6 +31,11 @@ export interface UsageTotals {
  * the last such line and surface its cost only when non-zero — pricing-disabled
  * or unpriced runs report zeros, in which case `cost` is left undefined and the
  * footer omits it.
+ *
+ * `toolCalls` is the total number of tool calls the agent made, summed from
+ * every assistant message's `tool_calls[]` (counted independently of token
+ * usage, so calls on a token-less turn still count). It pairs with the footer's
+ * failed-tool-call list to give a success rate.
  */
 export async function extractUsage(path: string): Promise<UsageTotals> {
   const totals: UsageTotals = {
@@ -37,6 +43,7 @@ export async function extractUsage(path: string): Promise<UsageTotals> {
     completionTokens: 0,
     totalTokens: 0,
     requests: 0,
+    toolCalls: 0,
   };
 
   if (!existsSync(path)) return totals;
@@ -63,6 +70,7 @@ export async function extractUsage(path: string): Promise<UsageTotals> {
       continue;
     }
     if (!isAssistantMessage(msg)) continue;
+    if (msg.tool_calls) totals.toolCalls += msg.tool_calls.length;
     const usage = msg.token_usage;
     if (!usage) continue;
     const prompt = numeric(usage.prompt_tokens);


### PR DESCRIPTION
## Summary

Closes #43.

The result comment footer surfaced only the *failed* tool calls. This adds the **total** number of tool calls the agent made plus a **success-rate percentage**, so failures can be read in proportion. The total is also exposed as a machine-readable action output.

## What changed

- **`src/usage.ts`** — count tool calls in `extractUsage`'s existing single pass (`UsageTotals.toolCalls`), summed from every assistant message's `tool_calls[]` (counted independently of token usage, beside the existing `requests` counter).
- **`src/post-results.ts`** — new exported `formatToolCalls(total, failed)` that computes a clamped success rate; rendered in `buildFooter` (gated on `toolCalls > 0`); sets a new `total-count` output.
- **`action.yml`** — new `total-tool-calls-count` output, mirroring `failed-tool-calls-count`.
- **Tests** — `usage.test.ts` counting cases (parallel calls, summing, token-less turns, non-assistant lines); `post-results.test.ts` `formatToolCalls` suite (100% / rounding / 0% / clamp / separators).
- **`README.md`** — result-posting bullet + filled-in Outputs table (also documents the previously-undocumented `failed-tool-calls-count`).
- **`dist/post-results/index.js`** — rebuilt via `npm run package`.

## Rendered footer (2 tool calls, 1 failed)

~~~
**Cost:** $0.04 in · $0.02 out · $0.06 total

**Tool calls:** 2 total · 50% success rate

<details><summary>⚠️ 1 failed tool call(s)</summary>
...
~~~

## Acceptance criteria

- [x] The amount of total tool calls is shown for the user
- [x] It's tested
- [x] It's documented