### PR TITLE
ci: push release as the bypass app token, not the default GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,5 +59,5 @@ jobs:
 
       - name: Run semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: semantic-release


### PR DESCRIPTION
## Problem

The manually-dispatched **Release** workflow failed: [run 27163677726](https://github.com/inference-gateway/infer-action/actions/runs/27163677726/job/80185291907).

`@semantic-release/git` could not push the release commit + tag to `main`:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
remote: - Commits must have verified signatures.
remote:   Found 1 violation: c48adf453783f9f9d00ddb47235fe582fe7a0c15
```

## Root cause

The `push-main` ruleset was tightened (2026-06-08 18:44) to enforce `pull_request` + `required_signatures` on the default branch. Its bypass list is exactly **`OrganizationAdmin`** and **`Integration 1211838`** = the `inference-gateway-releaser-bot` GitHub App.

The workflow mints an app token (`steps.app-token.outputs.token`) and uses it for checkout, but the `Run semantic-release` step passed `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` — the default `github-actions[bot]`. `@semantic-release/git` builds its push URL from that env var, so the push ran as `github-actions[bot]`, which is **not** a bypass actor → rejected.

## Fix

Route semantic-release through the already-minted releaser-bot app token:

```diff
       - name: Run semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: semantic-release
```

Because the releaser-bot app is a bypass actor (`bypass_mode: always`), pushing as the app bypasses the entire ruleset (PR rule + signatures + linear history) - no GPG signing or PR-based release flow needed. This also aligns `infer-action` with the established org pattern: **`inference-gateway/cli`** and **`inference-gateway/operator`** already pass the app token to their semantic-release step.

## Scope

CI-only change (`.github/workflows/release.yml`). No public surface, no docs ticket needed.