### PR TITLE
fix: keep View Job link pinned in cooking comment across all states

### DIFF
--- a/__tests__/runner-plan.test.ts
+++ b/__tests__/runner-plan.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { renderPlan } from "../src/runner.js";
+import { SPINNER_BLOCK, stripSpinner } from "../src/github.js";
+import type { Todo } from "../src/types.js";
+
+const WORKFLOW_URL = "https://github.com/acme/widgets/actions/runs/42";
+
+const TODOS: Todo[] = [
+  { id: "1", content: "Read codebase", status: "completed" },
+  { id: "2", content: "Write tests", status: "in_progress" },
+  { id: "3", content: "Rebuild dist/", status: "pending" },
+];
+
+describe("renderPlan", () => {
+  it("pins the View Job link below the spinner, above the todos", () => {
+    const out = renderPlan(TODOS, WORKFLOW_URL);
+    expect(out).toContain(SPINNER_BLOCK);
+    expect(out).toContain(`[View Job](${WORKFLOW_URL})`);
+    expect(out).toContain("### Todos");
+    expect(out).toContain("- [x] Read codebase");
+    expect(out).toContain("- [~] Write tests");
+    expect(out).toContain("- [ ] Rebuild dist/");
+    // The link is pinned at the top, so it never scrolls away behind the plan.
+    expect(out.indexOf("[View Job]")).toBeLessThan(out.indexOf("### Todos"));
+  });
+
+  it("keeps the View Job link when the agent has not posted todos yet", () => {
+    const out = renderPlan([], WORKFLOW_URL);
+    expect(out).toContain(`[View Job](${WORKFLOW_URL})`);
+    expect(out).toContain("_(agent has not posted a plan yet)_");
+  });
+
+  it("omits the link gracefully when no workflow URL is available", () => {
+    expect(renderPlan(TODOS, "")).not.toContain("View Job");
+    expect(renderPlan([], "")).not.toContain("View Job");
+  });
+
+  it("survives the end-of-run spinner clear (link outlives the spinner)", () => {
+    const stripped = stripSpinner(renderPlan(TODOS, WORKFLOW_URL));
+    expect(stripped).not.toContain("infer:spinner");
+    expect(stripped).toContain(`[View Job](${WORKFLOW_URL})`);
+    expect(stripped).toContain("- [x] Read codebase");
+  });
+});

--- a/action.yml
+++ b/action.yml
@@ -497,9 +497,9 @@ runs:
 
         COOKING_MESSAGE="<!-- infer:spinner --><img src=\"https://raw.githubusercontent.com/inference-gateway/infer-action/main/assets/spinner.svg\" width=\"22\" height=\"22\" alt=\"Working\" /><!-- /infer:spinner -->
 
-        I'm cooking...will get back to you soon...
+        [View Job](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
-        [View Job](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+        I'm cooking...will get back to you soon..."
 
         COMMENT_BODY=$(jq -n \
           --arg body "$COOKING_MESSAGE" \
@@ -652,6 +652,7 @@ runs:
         INFER_TRIGGERING_COMMENT_BODY: ${{ github.event.comment.body }}
         INFER_TRIGGERING_COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
         INFER_COOKING_COMMENT_ID: ${{ steps.cooking-message.outputs.cooking_comment_id }}
+        INFER_WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         INFER_CUSTOM_INSTRUCTIONS: ${{ inputs.custom-instructions }}
         INFER_PROMPT_OVERRIDE_SYSTEM_ISSUE: ${{ inputs.system-prompt-issue }}
         INFER_PROMPT_OVERRIDE_SYSTEM_PR: ${{ inputs.system-prompt-pr }}

--- a/dist/post-results/index.js
+++ b/dist/post-results/index.js
@@ -5098,7 +5098,7 @@ async function main() {
     const footer = buildFooter({
         exitCode,
         modelUsed,
-        workflowUrl,
+        workflowUrl: cookingCommentId > 0 ? "" : workflowUrl,
         durationMs,
         actor,
         agentResponse,

--- a/dist/runner/index.js
+++ b/dist/runner/index.js
@@ -248,6 +248,11 @@ function qstring(str) {
 /************************************************************************/
 var __webpack_exports__ = {};
 
+// EXPORTS
+__nccwpck_require__.d(__webpack_exports__, {
+  E: () => (/* binding */ renderPlan)
+});
+
 ;// CONCATENATED MODULE: external "node:child_process"
 const external_node_child_process_namespaceObject = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("node:child_process");
 ;// CONCATENATED MODULE: external "node:fs"
@@ -5313,6 +5318,7 @@ async function main() {
         ? Number.parseInt(cookingCommentIdRaw, 10)
         : 0;
     const hasCookingComment = Number.isFinite(cookingCommentId) && cookingCommentId > 0;
+    const workflowUrl = optional("INFER_WORKFLOW_URL");
     const model = required("INFER_AGENT_MODEL");
     const customInstructions = optional("INFER_CUSTOM_INSTRUCTIONS");
     const enableGitOps = optional("INFER_ENABLE_GIT_OPERATIONS") !== "false";
@@ -5405,7 +5411,7 @@ async function main() {
     const ticker = new Ticker();
     if (hasCookingComment) {
         const throttledTodos = throttleLatest(async (todos) => {
-            const markdown = renderPlan(todos);
+            const markdown = renderPlan(todos, workflowUrl);
             try {
                 await github.updateZone(cookingCommentId, "plan", markdown);
                 console.log(`[ticker] updated plan section (${todos.length} todos)`);
@@ -5458,9 +5464,19 @@ async function main() {
         : `Agent failed with exit code ${exitCode}`);
     return exitCode;
 }
-function renderPlan(todos) {
+// Spinner + persistent "View Job" link, re-emitted on every plan update so a
+// TodoWrite never erases them (mirrors the spinner contract in github.ts).
+// clearSpinner strips the spinner on finish; the View Job link stays pinned at
+// the top of the comment through every state.
+function renderHeader(workflowUrl) {
+    return workflowUrl
+        ? `${SPINNER_BLOCK}\n\n[View Job](${workflowUrl})`
+        : SPINNER_BLOCK;
+}
+function renderPlan(todos, workflowUrl) {
+    const header = renderHeader(workflowUrl);
     if (todos.length === 0) {
-        return `${SPINNER_BLOCK}\n\n### Todos\n\n_(agent has not posted a plan yet)_`;
+        return `${header}\n\n### Todos\n\n_(agent has not posted a plan yet)_`;
     }
     const lines = todos.map((t) => {
         const checkbox = t.status === "completed"
@@ -5470,7 +5486,7 @@ function renderPlan(todos) {
                 : "[ ]";
         return `- ${checkbox} ${t.content}`;
     });
-    return [SPINNER_BLOCK, "", "### Todos", "", ...lines].join("\n");
+    return [header, "", "### Todos", "", ...lines].join("\n");
 }
 function ensurePrHeadCheckedOut(ctx) {
     try {
@@ -5652,8 +5668,15 @@ function setOutput(name, value) {
         (0,external_node_fs_namespaceObject.appendFileSync)(file, `${name}=${value}\n`);
     }
 }
-main().then((code) => process.exit(code), (e) => {
-    console.error("[runner] uncaught error:", e);
-    process.exit(1);
-});
+// Auto-run only as the CLI entrypoint. Vitest imports this module to unit-test
+// renderPlan, so skip main() under the test runner to keep importing side-effect
+// free. VITEST is never set in the action runtime, so production is unchanged.
+if (!process.env["VITEST"]) {
+    main().then((code) => process.exit(code), (e) => {
+        console.error("[runner] uncaught error:", e);
+        process.exit(1);
+    });
+}
 
+var __webpack_exports__renderPlan = __webpack_exports__.E;
+export { __webpack_exports__renderPlan as renderPlan };

--- a/src/post-results.ts
+++ b/src/post-results.ts
@@ -53,7 +53,7 @@ async function main(): Promise<number> {
   const footer = buildFooter({
     exitCode,
     modelUsed,
-    workflowUrl,
+    workflowUrl: cookingCommentId > 0 ? "" : workflowUrl,
     durationMs,
     actor,
     agentResponse,

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -33,6 +33,7 @@ async function main(): Promise<number> {
     : 0;
   const hasCookingComment =
     Number.isFinite(cookingCommentId) && cookingCommentId > 0;
+  const workflowUrl = optional("INFER_WORKFLOW_URL");
   const model = required("INFER_AGENT_MODEL");
   const customInstructions = optional("INFER_CUSTOM_INSTRUCTIONS");
   const enableGitOps = optional("INFER_ENABLE_GIT_OPERATIONS") !== "false";
@@ -147,7 +148,7 @@ async function main(): Promise<number> {
   const ticker = new Ticker();
   if (hasCookingComment) {
     const throttledTodos = throttleLatest<Todo[]>(async (todos) => {
-      const markdown = renderPlan(todos);
+      const markdown = renderPlan(todos, workflowUrl);
       try {
         await github.updateZone(cookingCommentId, "plan", markdown);
         console.log(`[ticker] updated plan section (${todos.length} todos)`);
@@ -208,9 +209,20 @@ async function main(): Promise<number> {
   return exitCode;
 }
 
-function renderPlan(todos: Todo[]): string {
+// Spinner + persistent "View Job" link, re-emitted on every plan update so a
+// TodoWrite never erases them (mirrors the spinner contract in github.ts).
+// clearSpinner strips the spinner on finish; the View Job link stays pinned at
+// the top of the comment through every state.
+function renderHeader(workflowUrl: string): string {
+  return workflowUrl
+    ? `${SPINNER_BLOCK}\n\n[View Job](${workflowUrl})`
+    : SPINNER_BLOCK;
+}
+
+export function renderPlan(todos: Todo[], workflowUrl: string): string {
+  const header = renderHeader(workflowUrl);
   if (todos.length === 0) {
-    return `${SPINNER_BLOCK}\n\n### Todos\n\n_(agent has not posted a plan yet)_`;
+    return `${header}\n\n### Todos\n\n_(agent has not posted a plan yet)_`;
   }
   const lines = todos.map((t) => {
     const checkbox =
@@ -221,7 +233,7 @@ function renderPlan(todos: Todo[]): string {
           : "[ ]";
     return `- ${checkbox} ${t.content}`;
   });
-  return [SPINNER_BLOCK, "", "### Todos", "", ...lines].join("\n");
+  return [header, "", "### Todos", "", ...lines].join("\n");
 }
 
 function ensurePrHeadCheckedOut(ctx: PullRequestContext): void {
@@ -432,10 +444,15 @@ function setOutput(name: string, value: string): void {
   }
 }
 
-main().then(
-  (code) => process.exit(code),
-  (e) => {
-    console.error("[runner] uncaught error:", e);
-    process.exit(1);
-  },
-);
+// Auto-run only as the CLI entrypoint. Vitest imports this module to unit-test
+// renderPlan, so skip main() under the test runner to keep importing side-effect
+// free. VITEST is never set in the action runtime, so production is unchanged.
+if (!process.env["VITEST"]) {
+  main().then(
+    (code) => process.exit(code),
+    (e) => {
+      console.error("[runner] uncaught error:", e);
+      process.exit(1);
+    },
+  );
+}


### PR DESCRIPTION
## Summary

The bot's "I'm cooking…" comment lost its **View Job** link the moment the agent posted its first todo — the link only reappeared (in a different spot) in the final result footer.

Root cause: the comment's **plan zone** is rewritten on every `TodoWrite`. `renderPlan()` re-emitted the spinner on each update (so that survived) but **not** the `[View Job]` link the initial cooking message placed there, so the first `updateZone("plan", …)` erased it.

This pins **one** View Job link at the top of the comment, visible in every state (cooking → todos → PR → result).

## Changes

- **`src/runner.ts`** — `renderPlan()` now prepends `renderHeader(workflowUrl)` (spinner **+** `[View Job]`) on every render, re-emitting the link on each `TodoWrite` — the same contract the spinner already uses. Reads `INFER_WORKFLOW_URL`; `main()` is guarded under `VITEST` so `renderPlan` is importable for unit tests.
- **`action.yml`** — passes `INFER_WORKFLOW_URL` to the `run-agent` step, and reorders the initial cooking message so the link sits directly under the spinner (consistent placement before the first todo arrives).
- **`src/post-results.ts`** — drops the duplicate `[View Job]` from the result footer when a cooking comment owns the header (kept for the headerless direct / POST-fallback path).
- **`__tests__/runner-plan.test.ts`** — new unit tests: link present with todos, present with empty todos, omitted when no URL, and surviving the end-of-run spinner strip.
- **`dist/`** — rebuilt with `npm run package`.

## Verification

- `npm run all` — 172 tests pass (incl. 4 new), lint + typecheck + format clean, `dist/` rebuilt (CI's `git diff --exit-code dist/` passes).
- `act` dry-run (`task test:comment`) — the link appears in the plan zone on **both** todo ticks, and there is **no** duplicate `[View Job]` in the footer.

## Before / After

- **Before:** link in the initial comment → **vanishes** once todos render → reappears only in the final footer.
- **After:** link pinned under the spinner, present through every state; a single link (no footer duplicate).
