### PR TITLE
fix(prompts): stop agent todos from auto-linking unrelated GitHub issues

### DIFF
--- a/__tests__/prompts.test.ts
+++ b/__tests__/prompts.test.ts
@@ -294,6 +294,19 @@ describe("buildSystemPrompt", () => {
     expect(out).toContain("NOT acceptable");
   });
 
+  it("warns that #N / @name in todos auto-link in the mirrored comment", () => {
+    for (const ctx of [issueCtx(), prCtx(), prCtx({ isFork: true })]) {
+      const out = buildSystemPrompt(ctx, "");
+      expect(out).toContain("pings a real");
+      expect(out).toContain("unrelated or non-existent ticket");
+    }
+  });
+
+  it("omits the auto-link guidance in the direct context (todos not mirrored)", () => {
+    const out = buildSystemPrompt(directCtx(), "");
+    expect(out).not.toContain("pings a real");
+  });
+
   it("issue variant tells the agent to continue an existing branch, not reset it", () => {
     const out = buildSystemPrompt(issueCtx(), "");
     expect(out).toContain("git fetch origin fix/issue-42");

--- a/dist/runner/index.js
+++ b/dist/runner/index.js
@@ -4289,6 +4289,13 @@ Use TodoWrite to track your plan. Update it as you make progress - the
 runner publishes your todos to the issue comment automatically, so you do
 not need to comment on the issue yourself.
 
+Your todos render as Markdown in that comment, where GitHub turns \`#123\`
+into a link to issue/PR 123 and \`@name\` into a mention that pings a real
+user. Only write \`#123\` or \`@name\` when you deliberately mean that exact
+issue, PR, or person. For ordinary numbering or counts inside a todo, drop
+the \`#\` - write "step 1", "3 of 5 files", "PR 96" - so you never link an
+unrelated or non-existent ticket.
+
 For questions or discussion (no code changes), just answer and stop -
 skip the steps below.
 
@@ -4399,6 +4406,13 @@ been fetched read-only for you to inspect.
 Use TodoWrite to track your plan. Update it as you make progress - the
 runner publishes your todos to the PR comment automatically.
 
+Your todos render as Markdown in that comment, where GitHub turns \`#123\`
+into a link to issue/PR 123 and \`@name\` into a mention that pings a real
+user. Only write \`#123\` or \`@name\` when you deliberately mean that exact
+issue, PR, or person. For ordinary numbering or counts inside a todo, drop
+the \`#\` - write "step 1", "3 of 5 files", "PR 96" - so you never link an
+unrelated or non-existent ticket.
+
 The user's latest ask is in the "Triggering comment" section of your task.
 Address that ask directly.
 
@@ -4438,6 +4452,13 @@ push is lost when the job ends.
 Use TodoWrite to track your plan. Update it as you make progress - the
 runner publishes your todos to the PR comment automatically, so you do
 not need to comment on the PR yourself.
+
+Your todos render as Markdown in that comment, where GitHub turns \`#123\`
+into a link to issue/PR 123 and \`@name\` into a mention that pings a real
+user. Only write \`#123\` or \`@name\` when you deliberately mean that exact
+issue, PR, or person. For ordinary numbering or counts inside a todo, drop
+the \`#\` - write "step 1", "3 of 5 files", "PR 96" - so you never link an
+unrelated or non-existent ticket.
 
 The user's latest ask is in the "Triggering comment" section of your task.
 Address that ask directly. Do NOT re-implement existing changes unless

--- a/src/prompts/system-issue.md
+++ b/src/prompts/system-issue.md
@@ -11,6 +11,13 @@ Use TodoWrite to track your plan. Update it as you make progress - the
 runner publishes your todos to the issue comment automatically, so you do
 not need to comment on the issue yourself.
 
+Your todos render as Markdown in that comment, where GitHub turns `#123`
+into a link to issue/PR 123 and `@name` into a mention that pings a real
+user. Only write `#123` or `@name` when you deliberately mean that exact
+issue, PR, or person. For ordinary numbering or counts inside a todo, drop
+the `#` - write "step 1", "3 of 5 files", "PR 96" - so you never link an
+unrelated or non-existent ticket.
+
 For questions or discussion (no code changes), just answer and stop -
 skip the steps below.
 

--- a/src/prompts/system-pr-fork.md
+++ b/src/prompts/system-pr-fork.md
@@ -9,6 +9,13 @@ been fetched read-only for you to inspect.
 Use TodoWrite to track your plan. Update it as you make progress - the
 runner publishes your todos to the PR comment automatically.
 
+Your todos render as Markdown in that comment, where GitHub turns `#123`
+into a link to issue/PR 123 and `@name` into a mention that pings a real
+user. Only write `#123` or `@name` when you deliberately mean that exact
+issue, PR, or person. For ordinary numbering or counts inside a todo, drop
+the `#` - write "step 1", "3 of 5 files", "PR 96" - so you never link an
+unrelated or non-existent ticket.
+
 The user's latest ask is in the "Triggering comment" section of your task.
 Address that ask directly.
 

--- a/src/prompts/system-pr.md
+++ b/src/prompts/system-pr.md
@@ -12,6 +12,13 @@ Use TodoWrite to track your plan. Update it as you make progress - the
 runner publishes your todos to the PR comment automatically, so you do
 not need to comment on the PR yourself.
 
+Your todos render as Markdown in that comment, where GitHub turns `#123`
+into a link to issue/PR 123 and `@name` into a mention that pings a real
+user. Only write `#123` or `@name` when you deliberately mean that exact
+issue, PR, or person. For ordinary numbering or counts inside a todo, drop
+the `#` - write "step 1", "3 of 5 files", "PR 96" - so you never link an
+unrelated or non-existent ticket.
+
 The user's latest ask is in the "Triggering comment" section of your task.
 Address that ask directly. Do NOT re-implement existing changes unless
 the user is asking for that.


### PR DESCRIPTION
## Summary

The runner mirrors the agent's `TodoWrite` list into the issue/PR comment as Markdown. When a todo contains a bare `#N` (the agent numbering sub-items or loosely quoting things), GitHub renders it as a link to issue/PR N - pulling in titles of **unrelated or non-existent** tickets. `@name` has the same hazard: it becomes a mention that pings a real user.

This is fixed **behaviorally in the default system prompts** rather than by escaping output. Escaping `#N`/`@name` in `renderPlan` was considered and rejected - it would also defuse the cases where the agent *deliberately* wants to link a real issue/PR (e.g. "Resolves #42"). Teaching the agent to reserve `#N`/`@name` for intentional references keeps real links working while killing the accidental ones.

## Changes

- Add a short guidance paragraph to the three **mirrored** system prompts (`system-issue.md`, `system-pr.md`, `system-pr-fork.md`): todos render as Markdown in the comment where `#123`/`@name` auto-link/ping, so use them only when deliberate, and number/count without `#` ("step 1", "PR 96").
- Leave `system-direct.md` unchanged - its todos are not mirrored to any comment, so the hazard doesn't apply.
- Add regression assertions in `__tests__/prompts.test.ts` (guidance present in the three mirrored contexts, absent from direct).
- Regenerate the bundled `dist/runner/index.js` (only bundle that embeds prompts).

## Verification

- `bun run package` → only `dist/runner/index.js` changes
- `bun run test` (223 pass, 0 fail), `bun run typecheck`, `bun run lint` clean