### PR TITLE
fix(prompts): forbid committing or pushing to main

### DIFF
--- a/dist/runner/index.js
+++ b/dist/runner/index.js
@@ -4237,6 +4237,9 @@ skip the steps below. Your answer is your final output.
 If you will make code changes, follow this order. Do NOT defer commits to
 the end of the run.
 
+NEVER commit on or push to \`main\`/\`master\` - branch protection rejects the
+push and the work is stranded. All work happens on the working branch.
+
 1. BEFORE any file edits, create and push a working branch off the default
    branch. Choose a short, descriptive kebab-case name:
 
@@ -4244,14 +4247,18 @@ the end of the run.
        git push -u origin infer/<short-description>
 
    (for example \`infer/add-rate-limit-header\`). Do not call Edit/Write
-   before this step succeeds - those edits will be lost.
+   before this step succeeds - those edits will be lost. Before your first
+   edit, confirm \`git branch --show-current\` does NOT report \`main\` or
+   \`master\`.
 
 2. AFTER each TodoWrite item you flip to "completed", validate then commit:
 
        <run the repo's checks and fix any failures>
        git add -A
        git commit -m "<type>(<scope>): <description>"
-       git push
+       git push origin infer/<short-description>
+
+   Push your working branch by name - never \`main\`.
 
    Before committing, run the repository's own checks - lint, format,
    type-check, tests (e.g. \`npm run lint\`, \`npm test\`, \`task lint\` -
@@ -4364,6 +4371,9 @@ skip the steps below.
 If you will make code changes, follow this order. Do NOT defer commits to
 the end of the run.
 
+NEVER commit on or push to \`main\`/\`master\` - branch protection rejects the
+push and the work is stranded. All work happens on the working branch.
+
 1. BEFORE any file edits, get onto the working branch. Do not call
    Edit/Write before this step succeeds - those edits will be lost.
 
@@ -4383,12 +4393,18 @@ the end of the run.
    Never run \`git checkout -B\` against an existing branch - that throws away
    the prior commits. Already on another branch? Stay on it.
 
+   Before your first edit, confirm \`git branch --show-current\` does NOT
+   report \`main\` or \`master\`. If it does, go back and create the branch.
+
 2. AFTER each TodoWrite item you flip to "completed", validate then commit:
 
        <run the repo's checks and fix any failures>
        git add -A
        git commit -m "<type>(<scope>): <description>"
-       git push
+       git push origin fix/issue-{{issueNumber}}
+
+   (If step 1 put you on a different branch, push that branch by name
+   instead - never \`main\`.)
 
    Before committing, run the repository's own checks - lint, format,
    type-check, tests (e.g. \`npm run lint\`, \`npm test\`, \`task lint\` -
@@ -4856,7 +4872,7 @@ function contextReminderText(ctx) {
   if (ctx.kind === "pull_request") {
     return `<system-reminder>Keep your TodoWrite plan current, and commit + push after each step so PR #${ctx.prNumber} stays current - unpushed work is lost when the job ends.</system-reminder>`;
   }
-  return "<system-reminder>Keep your TodoWrite plan current. Changing code? Work on a pushed branch with an open draft PR (`gh pr create --draft`) and commit + push after each step so nothing is lost. Only answering a question? Ignore this.</system-reminder>";
+  return "<system-reminder>Keep your TodoWrite plan current. Changing code? Work on a pushed branch with an open draft PR (`gh pr create --draft`) and commit + push after each step so nothing is lost - never commit on or push to main. Only answering a question? Ignore this.</system-reminder>";
 }
 function wrapUpText(ctx) {
   const target = ctx.kind === "pull_request" ? `so PR #${ctx.prNumber} is up to date` : "and make sure the draft PR exists (`gh pr create --draft`)";

--- a/src/prompts/system-direct.md
+++ b/src/prompts/system-direct.md
@@ -35,6 +35,9 @@ skip the steps below. Your answer is your final output.
 If you will make code changes, follow this order. Do NOT defer commits to
 the end of the run.
 
+NEVER commit on or push to `main`/`master` - branch protection rejects the
+push and the work is stranded. All work happens on the working branch.
+
 1. BEFORE any file edits, create and push a working branch off the default
    branch. Choose a short, descriptive kebab-case name:
 
@@ -42,14 +45,18 @@ the end of the run.
        git push -u origin infer/<short-description>
 
    (for example `infer/add-rate-limit-header`). Do not call Edit/Write
-   before this step succeeds - those edits will be lost.
+   before this step succeeds - those edits will be lost. Before your first
+   edit, confirm `git branch --show-current` does NOT report `main` or
+   `master`.
 
 2. AFTER each TodoWrite item you flip to "completed", validate then commit:
 
        <run the repo's checks and fix any failures>
        git add -A
        git commit -m "<type>(<scope>): <description>"
-       git push
+       git push origin infer/<short-description>
+
+   Push your working branch by name - never `main`.
 
    Before committing, run the repository's own checks - lint, format,
    type-check, tests (e.g. `npm run lint`, `npm test`, `task lint` -

--- a/src/prompts/system-issue.md
+++ b/src/prompts/system-issue.md
@@ -40,6 +40,9 @@ skip the steps below.
 If you will make code changes, follow this order. Do NOT defer commits to
 the end of the run.
 
+NEVER commit on or push to `main`/`master` - branch protection rejects the
+push and the work is stranded. All work happens on the working branch.
+
 1. BEFORE any file edits, get onto the working branch. Do not call
    Edit/Write before this step succeeds - those edits will be lost.
 
@@ -59,12 +62,18 @@ the end of the run.
    Never run `git checkout -B` against an existing branch - that throws away
    the prior commits. Already on another branch? Stay on it.
 
+   Before your first edit, confirm `git branch --show-current` does NOT
+   report `main` or `master`. If it does, go back and create the branch.
+
 2. AFTER each TodoWrite item you flip to "completed", validate then commit:
 
        <run the repo's checks and fix any failures>
        git add -A
        git commit -m "<type>(<scope>): <description>"
-       git push
+       git push origin fix/issue-{{issueNumber}}
+
+   (If step 1 put you on a different branch, push that branch by name
+   instead - never `main`.)
 
    Before committing, run the repository's own checks - lint, format,
    type-check, tests (e.g. `npm run lint`, `npm test`, `task lint` -

--- a/src/reminders.ts
+++ b/src/reminders.ts
@@ -82,7 +82,7 @@ function contextReminderText(ctx: TaskContext): string {
   if (ctx.kind === "pull_request") {
     return `<system-reminder>Keep your TodoWrite plan current, and commit + push after each step so PR #${ctx.prNumber} stays current - unpushed work is lost when the job ends.</system-reminder>`;
   }
-  return "<system-reminder>Keep your TodoWrite plan current. Changing code? Work on a pushed branch with an open draft PR (`gh pr create --draft`) and commit + push after each step so nothing is lost. Only answering a question? Ignore this.</system-reminder>";
+  return "<system-reminder>Keep your TodoWrite plan current. Changing code? Work on a pushed branch with an open draft PR (`gh pr create --draft`) and commit + push after each step so nothing is lost - never commit on or push to main. Only answering a question? Ignore this.</system-reminder>";
 }
 
 function wrapUpText(ctx: TaskContext): string {


### PR DESCRIPTION
## Summary

A run on issue #145 with a weak model (`ollama_cloud/deepseek-v4-flash`) committed on `main` and ran a bare `git push`, which GitHub rejected with GH013 branch-protection violations before the agent self-corrected onto a branch. The action's system prompts instructed branching but never explicitly forbade `main`, and the commit-loop examples used a bare `git push`. This hardens the prompts and the periodic reminder so weak models get an explicit prohibition and explicit push refspecs.

## Changes

- `src/prompts/system-issue.md`: add a "NEVER commit on or push to `main`/`master`" prohibition to the Code changes section, a `git branch --show-current` self-check before the first edit, and replace the bare `git push` example with `git push origin fix/issue-{{issueNumber}}` (plus a note to push a continued branch by name)
- `src/prompts/system-direct.md`: same prohibition and self-check, with `git push origin infer/<short-description>` as the explicit push form
- `src/reminders.ts`: the periodic issue/direct context reminder now ends with "never commit on or push to main" so the rule re-fires throughout the run
- `dist/runner/index.js`: rebuilt via `bun run package`

`system-pr.md` is untouched (it already pins the agent to the PR head branch), as is the salvage path's existing never-push-main guard. Mechanically narrowing the `git push( .*)?` allow-list entry is deliberately out of scope: Go RE2 cannot express negation, per-context refspec enumeration would break legitimate PR-branch pushes, and branch protection remains the mechanical backstop.
