### PR TITLE
ci(release): install @semantic-release/exec@^7 instead of ^1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
           npm install -g \
             semantic-release@^25 \
             @semantic-release/changelog@^6 \
-            @semantic-release/exec@^1 \
+            @semantic-release/exec@^7 \
             @semantic-release/git@^10 \
             @semantic-release/github@^12 \
             @semantic-release/npm@^13 \


### PR DESCRIPTION
The release workflow installed `@semantic-release/exec@^1`, a version predating `prepareCmd` support — its verify step only accepts a single `cmd` option, so the run failed with `EINVALIDCMD: The script plugin must be configured with the shell command to execute in the a "cmd" option` (run 28704503133). Bump to `^7`, the current major, which supports the per-lifecycle `prepareCmd` used in `.releaserc.yaml`.