### PR TITLE
fix: pass github-token to the plugins install step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -928,6 +928,8 @@ runs:
       id: install-plugins
       if: steps.check-trigger.outputs.triggered == 'true' && inputs.dry-run != 'true' && inputs.plugins != ''
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
         set -e
 


### PR DESCRIPTION
Resolves #190

## Summary

Runs with `plugins:` set were failing with "Github API rate limit exceeded (60 req/hour for unauthenticated requests)". The failing run (inference-gateway/cli run 28965103268) shows the error fires in the `Install Infer plugins` step while installing a plugin - plugins bundle skills, hence the issue title. The `Install Infer skills` step already passes `GITHUB_TOKEN` (added in #33 for the identical bug), but the plugins step had no `env:` block at all, so `infer plugins install` ran unauthenticated. The CLI already reads `GITHUB_TOKEN`/`GH_TOKEN`, so the fix is action-side only.

## Changes

- Add `GITHUB_TOKEN: ${{ inputs.github-token }}` to the `Install Infer plugins` step in `action.yml`, mirroring the skills step.

The issue's suggestion to cache skills in GitHub is skipped for now: authenticated requests get 5,000 req/hour, which covers the reported failure.
