### PR TITLE
fix(action): download infer via authenticated gh release download to avoid 429

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -843,9 +843,16 @@ runs:
       id: install-cli
       if: steps.check-trigger.outputs.triggered == 'true' && inputs.dry-run != 'true'
       shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
       run: |
         VERSION="${{ inputs.version }}"
-        curl -fsSL https://raw.githubusercontent.com/inference-gateway/cli/main/install.sh | bash -s -- ${VERSION:+--version $VERSION}
+        if [[ -z "$VERSION" ]]; then
+          VERSION=$(gh release view --repo inference-gateway/cli --json tagName --jq .tagName)
+        fi
+        gh release download "$VERSION" --repo inference-gateway/cli \
+          --pattern "infer-linux-amd64" --output /usr/local/bin/infer --clobber
+        chmod +x /usr/local/bin/infer
         infer version
 
     - name: Initialize Infer userspace config

--- a/action.yml
+++ b/action.yml
@@ -850,8 +850,12 @@ runs:
         if [[ -z "$VERSION" ]]; then
           VERSION=$(gh release view --repo inference-gateway/cli --json tagName --jq .tagName)
         fi
+        case "${RUNNER_ARCH}" in
+          ARM64) ARCH=arm64 ;;
+          *) ARCH=amd64 ;;
+        esac
         gh release download "$VERSION" --repo inference-gateway/cli \
-          --pattern "infer-linux-amd64" --output /usr/local/bin/infer --clobber
+          --pattern "infer-linux-${ARCH}" --output /usr/local/bin/infer --clobber
         chmod +x /usr/local/bin/infer
         infer version
 


### PR DESCRIPTION
## Problem

The **Install Infer CLI** step pipes `install.sh` from raw.githubusercontent.com unauthenticated. Shared runner IPs regularly hit the per-IP rate limit, failing runs with `curl: (22) The requested URL returned error: 429` — e.g. https://github.com/inference-gateway/cli/actions/runs/28982828993/job/86005260946. The script's internal release-binary download is also unauthenticated and can 429 the same way.

## Fix

Replace the `curl | bash` install with `gh release download` authenticated via the action's `github-token` input (5000 req/hr, no shared-IP raw limit). Resolves `inputs.version` when set, otherwise the latest release, and picks the binary matching `RUNNER_ARCH` (amd64/arm64).