### PR TITLE
fix(git): attribute agent commits to the app bot, not github-actions[bot]

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,9 +15,20 @@ inputs:
     description: |
       Slug of the GitHub App whose bot identity should author the agent's
       commits (e.g. "infer-bot"). When set, commits are attributed to
-      "<slug>[bot]" and the numeric id is resolved via GET /users/{slug}[bot]
-      (which works with an App installation token, unlike GET /user). Falls
-      back to github-actions[bot] when empty or if the lookup fails.
+      "<slug>[bot]" and the numeric id is taken from `github-app-user-id` if
+      provided, otherwise resolved via GET /users/{slug}[bot] (which works with
+      an App installation token, unlike GET /user). Falls back to
+      github-actions[bot] when empty or if the id cannot be resolved.
+    required: false
+    default: ""
+
+  github-app-user-id:
+    description: |
+      Numeric user id of the GitHub App bot ("<slug>[bot]"). When set, it is
+      used directly to build the commit author email, skipping the
+      GET /users/{slug}[bot] lookup. Prefer passing this from a step that has
+      already resolved it (the reusable workflow does), so commit attribution
+      does not depend on a second, flaky API call.
     required: false
     default: ""
 
@@ -1021,6 +1032,7 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.github-token }}
         APP_SLUG: ${{ inputs.github-app-slug }}
+        APP_USER_ID: ${{ inputs.github-app-user-id }}
       run: |
         set -euo pipefail
 
@@ -1028,7 +1040,17 @@ runs:
         BOT_ID=""
         if [[ -n "${APP_SLUG:-}" ]]; then
           BOT_LOGIN="${APP_SLUG}[bot]"
-          BOT_ID="$(gh api "/users/${APP_SLUG}[bot]" --jq '.id' 2>/dev/null || true)"
+          if [[ "${APP_USER_ID:-}" =~ ^[0-9]+$ ]]; then
+            # Caller pre-resolved the id; trust it and skip the API lookup.
+            BOT_ID="$APP_USER_ID"
+          else
+            # Not pre-resolved: look it up. Don't swallow the failure silently -
+            # a missed id here is what mis-attributes commits to github-actions[bot].
+            BOT_ID="$(gh api "/users/${APP_SLUG}[bot]" --jq '.id' || true)"
+            if [[ ! "$BOT_ID" =~ ^[0-9]+$ ]]; then
+              echo "::warning::Could not resolve id for ${APP_SLUG}[bot] (pass github-app-user-id to avoid this lookup); falling back to github-actions[bot]"
+            fi
+          fi
         fi
 
         if [[ -z "$BOT_LOGIN" || ! "$BOT_ID" =~ ^[0-9]+$ ]]; then

--- a/action.yml
+++ b/action.yml
@@ -1041,11 +1041,8 @@ runs:
         if [[ -n "${APP_SLUG:-}" ]]; then
           BOT_LOGIN="${APP_SLUG}[bot]"
           if [[ "${APP_USER_ID:-}" =~ ^[0-9]+$ ]]; then
-            # Caller pre-resolved the id; trust it and skip the API lookup.
             BOT_ID="$APP_USER_ID"
           else
-            # Not pre-resolved: look it up. Don't swallow the failure silently -
-            # a missed id here is what mis-attributes commits to github-actions[bot].
             BOT_ID="$(gh api "/users/${APP_SLUG}[bot]" --jq '.id' || true)"
             if [[ ! "$BOT_ID" =~ ^[0-9]+$ ]]; then
               echo "::warning::Could not resolve id for ${APP_SLUG}[bot] (pass github-app-user-id to avoid this lookup); falling back to github-actions[bot]"


### PR DESCRIPTION
The @infer agent's pushed commits intermittently show up as `github-actions[bot]` (id 41898282) with the generic Actions avatar instead of the App bot (e.g. `inference-gateway-maintainer[bot]`, id 246577062). Confirmed on a live PR where both branch commits were authored and committed by github-actions[bot] with no Signed-off-by trailer.

The cause is the Configure Git step. It re-resolved the bot id a second time via `gh api /users/<slug>[bot]`, with the failure swallowed by `2>/dev/null || true`, and fell back to github-actions[bot] whenever that lookup returned empty or non-numeric. Because it is a duplicate, network-dependent lookup, it fails intermittently even though the reusable workflow has already resolved the same id reliably.

This change adds an optional `github-app-user-id` input. When the caller passes an already-resolved numeric id, the action uses it directly and skips the API lookup entirely, so commit attribution no longer depends on a second flaky call. When the id still has to be looked up, a failure now surfaces as a warning instead of being silently swallowed, and github-actions[bot] remains only as a genuine last resort.

The reusable infer.yml workflow is updated in a companion PR to pass `github-app-user-id` from its existing get-user-id step.