### PR TITLE
fix: un-gate A2A tool approval when the action registers A2A agents

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1043,15 +1043,7 @@ runs:
         done <<< "$ENTRIES"
 
         if [[ "$ANY_ADDED" == "true" ]]; then
-          # Enable A2A so `infer agent` starts the registered containers and
-          # exposes them to the model via the A2A tools.
           echo "INFER_A2A_ENABLED=true" >> "$GITHUB_ENV"
-          # Un-gate the A2A tools for this unattended run, same rationale as the
-          # Write/Edit/Delete approvals on the run step: headless has no approver,
-          # so a gated tool resolves to `block` and is rejected. SubmitTask
-          # auto-polls via QueryTask in the background, so un-gate the poll too;
-          # QueryAgent/QueryTask are read-only. Scoped to runs that actually
-          # register agents, so chat/desktop and non-A2A runs are unaffected.
           echo "INFER_A2A_TOOLS_SUBMIT_TASK_REQUIRE_APPROVAL=false" >> "$GITHUB_ENV"
           echo "INFER_A2A_TOOLS_QUERY_TASK_REQUIRE_APPROVAL=false" >> "$GITHUB_ENV"
           echo "INFER_A2A_TOOLS_QUERY_AGENT_REQUIRE_APPROVAL=false" >> "$GITHUB_ENV"

--- a/action.yml
+++ b/action.yml
@@ -1046,6 +1046,15 @@ runs:
           # Enable A2A so `infer agent` starts the registered containers and
           # exposes them to the model via the A2A tools.
           echo "INFER_A2A_ENABLED=true" >> "$GITHUB_ENV"
+          # Un-gate the A2A tools for this unattended run, same rationale as the
+          # Write/Edit/Delete approvals on the run step: headless has no approver,
+          # so a gated tool resolves to `block` and is rejected. SubmitTask
+          # auto-polls via QueryTask in the background, so un-gate the poll too;
+          # QueryAgent/QueryTask are read-only. Scoped to runs that actually
+          # register agents, so chat/desktop and non-A2A runs are unaffected.
+          echo "INFER_A2A_TOOLS_SUBMIT_TASK_REQUIRE_APPROVAL=false" >> "$GITHUB_ENV"
+          echo "INFER_A2A_TOOLS_QUERY_TASK_REQUIRE_APPROVAL=false" >> "$GITHUB_ENV"
+          echo "INFER_A2A_TOOLS_QUERY_AGENT_REQUIRE_APPROVAL=false" >> "$GITHUB_ENV"
           echo ""
           echo "Configured A2A agents:"
           infer agents list || true


### PR DESCRIPTION
When `infer-action` runs headless in CI and the model tries to delegate work to a configured A2A agent (e.g. `documentation-agent`), the `A2A_SubmitTask` tool is **blocked** — the agent reports it "requires approval which isn't available in this CI run" and proceeds manually, defeating the point of wiring up A2A agents for the run.

## Root cause

- A2A tool approval is a per-tool `*bool` override in the CLI (`config/config.go`, `case "A2A_SubmitTask"`: `c.A2A.Tools.SubmitTask.RequireApproval`). It is left **nil**, so it falls through to the global `tools.safety.require_approval`, which defaults to `true`.
- Headless there is no approver, so `ResolveApprovalDelivery` maps the needed approval to `block` and the tool call is rejected — the intended secure-by-default headless behaviour.
- This action already opts specific tools out of approval for unattended runs (the run step sets `INFER_TOOLS_WRITE/EDIT/DELETE_REQUIRE_APPROVAL: "false"`). But the **Setup A2A agents** step enables A2A (`INFER_A2A_ENABLED=true`) without doing the equivalent for the A2A tools, so they stay gated and get blocked.

## Change

In the `Setup A2A agents` step, under the existing `if [[ "$ANY_ADDED" == "true" ]]` branch that already writes `INFER_A2A_ENABLED=true`, also write the three A2A tool approval opt-outs to `$GITHUB_ENV`:

- `INFER_A2A_TOOLS_SUBMIT_TASK_REQUIRE_APPROVAL=false`
- `INFER_A2A_TOOLS_QUERY_TASK_REQUIRE_APPROVAL=false` — `A2A_SubmitTask` auto-polls via `QueryTask` in the background, so un-gating only submit would still risk a blocked poll
- `INFER_A2A_TOOLS_QUERY_AGENT_REQUIRE_APPROVAL=false` — read-only

Scoped to the `ANY_ADDED` branch, so the opt-out applies **only** when the action actually registered A2A agents. Chat/desktop and non-A2A CI runs are unaffected — secure-by-default is preserved.

## Verification

Trigger a consumer workflow that passes `agents:` (e.g. `documentation-agent`) with a prompt asking the agent to delegate a lookup, and confirm `A2A_SubmitTask` executes instead of being blocked.

## Follow-up (separate)

The CLI docs (`cli/docs/configuration-reference.md`) claim `INFER_A2A_TOOLS_SUBMIT_TASK_REQUIRE_APPROVAL` defaults to `false`, but the code defaults to the global `true`. Either register the viper default to match the docs or fix the docs — changing the CLI default would also alter interactive-chat behaviour, so this fix intentionally stays at the action level.
