### PR TITLE
feat: dump A2A agent container logs in cleanup when debug is on

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1788,6 +1788,14 @@ runs:
         if [[ -n "$AGENTS_INPUT" ]] && command -v docker >/dev/null 2>&1; then
           LEFTOVER="$(docker ps -aq --filter "name=inference-agent-" 2>/dev/null || true)"
           if [[ -n "$LEFTOVER" ]]; then
+            if [[ "$DEBUG" == "true" ]]; then
+              while IFS= read -r CONTAINER_ID; do
+                CONTAINER_NAME="$(docker inspect --format '{{.Name}}' "$CONTAINER_ID" 2>/dev/null | sed 's|^/||' || echo "$CONTAINER_ID")"
+                echo "::group::A2A agent logs: ${CONTAINER_NAME}"
+                docker logs "$CONTAINER_ID" 2>&1 | tail -500 || true
+                echo "::endgroup::"
+              done <<< "$LEFTOVER"
+            fi
             echo "Removing leftover A2A agent containers..."
             echo "$LEFTOVER" | xargs -r docker rm -f >/dev/null 2>&1 || true
           fi


### PR DESCRIPTION
## Summary

Diagnosing inference-gateway/infer-action#262 hit a wall: the run-agent transcript can only show the CLI side of an A2A exchange. In run 30708361016 the browser-agent took the screenshot 8 seconds after task submission, but the completion notification arrived ~6 minutes later referencing a container-local path — and nothing in the Action's logs can say what the agent was doing in between, or whether it ever published an artifact with a Download URL.

With `debug: true`, the always()-gated Cleanup step now dumps the last 500 log lines of every `inference-agent-*` container — one collapsed `::group::` per container — right before removing them, mirroring the existing otel-collector log dump in the same step. Because Cleanup runs on `always()`, the logs survive job timeouts and runner crashes.

## Changes

- `action.yml` (Cleanup step only): debug-gated `docker logs` dump per leftover A2A agent container. No `src/` or `dist/` changes.

## Verification

- `bun run all` green locally (format, eslint, markdownlint, typecheck, 366 tests, package — `dist/` unchanged).
- Observable on the next `debug: true` run with the `agents` input set: the Cleanup step shows a collapsed log group per agent container.
