### PR TITLE
fix: capture A2A agent logs before --rm removal and auto-approve WebFetch

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1170,6 +1170,7 @@ runs:
       shell: bash
       env:
         AGENT_MODEL: ${{ steps.check-trigger.outputs.model_override || inputs.model }}
+        DEBUG: ${{ inputs.debug }}
       run: |
         set -o pipefail
 
@@ -1256,6 +1257,30 @@ runs:
           echo ""
           echo "Configured A2A agents:"
           infer agents list || true
+
+          # Agent containers run with --rm and are docker-stopped by the CLI at
+          # session end, so their logs are gone before Cleanup can read them.
+          # A background watcher attaches `docker logs -f` to every
+          # inference-agent-* container as it appears (each CLI invocation
+          # starts its own session-suffixed container) and streams to files
+          # that Cleanup dumps after the run.
+          if [[ "$DEBUG" == "true" ]] && command -v docker >/dev/null 2>&1; then
+            AGENT_LOG_DIR="$RUNNER_TEMP/agent-logs"
+            mkdir -p "$AGENT_LOG_DIR"
+            (
+              SEEN=" "
+              while true; do
+                for ID in $(docker ps -q --filter "name=inference-agent-" 2>/dev/null); do
+                  [[ "$SEEN" == *" $ID "* ]] && continue
+                  SEEN="$SEEN$ID "
+                  NAME="$(docker inspect --format '{{.Name}}' "$ID" 2>/dev/null | sed 's|^/||')"
+                  docker logs -f "$ID" >> "$AGENT_LOG_DIR/${NAME:-$ID}.log" 2>&1 &
+                done
+                sleep 2
+              done
+            ) >/dev/null 2>&1 &
+            echo "Started A2A agent log capture (debug) -> $AGENT_LOG_DIR"
+          fi
         else
           echo "No A2A agents were registered; leaving A2A disabled."
         fi
@@ -1582,6 +1607,11 @@ runs:
         INFER_TOOLS_WRITE_REQUIRE_APPROVAL: "false"
         INFER_TOOLS_EDIT_REQUIRE_APPROVAL: "false"
         INFER_TOOLS_DELETE_REQUIRE_APPROVAL: "false"
+        # WebFetch otherwise falls through to the global tools.safety approval
+        # prompt, which no headless run can answer - it would hard-block the
+        # A2A artifact Download URL fetch. Domain safety still applies via
+        # tools.web_fetch.allowed_domains + the configured-agent-host exemption.
+        INFER_TOOLS_WEB_FETCH_REQUIRE_APPROVAL: "false"
         INFER_TOOLS_WEB_FETCH_ALLOWED_DOMAINS: ${{ inputs.web-fetch-domains || 'github.com,raw.githubusercontent.com,api.github.com' }}
         INFER_LOGGING_DEBUG: ${{ inputs.debug }}
         INFER_COMPACT_AUTO_AT: ${{ inputs.compact-auto-at }}
@@ -1786,16 +1816,19 @@ runs:
         fi
 
         if [[ -n "$AGENTS_INPUT" ]] && command -v docker >/dev/null 2>&1; then
+          # Agent containers run with --rm, so by now the CLI's docker stop has
+          # usually removed them - dump the log files the setup-agents watcher
+          # streamed while they were alive.
+          if [[ "$DEBUG" == "true" ]]; then
+            for LOG_FILE in "$RUNNER_TEMP"/agent-logs/*.log; do
+              [[ -e "$LOG_FILE" ]] || continue
+              echo "::group::A2A agent logs: $(basename "$LOG_FILE" .log)"
+              tail -500 "$LOG_FILE" || true
+              echo "::endgroup::"
+            done
+          fi
           LEFTOVER="$(docker ps -aq --filter "name=inference-agent-" 2>/dev/null || true)"
           if [[ -n "$LEFTOVER" ]]; then
-            if [[ "$DEBUG" == "true" ]]; then
-              while IFS= read -r CONTAINER_ID; do
-                CONTAINER_NAME="$(docker inspect --format '{{.Name}}' "$CONTAINER_ID" 2>/dev/null | sed 's|^/||' || echo "$CONTAINER_ID")"
-                echo "::group::A2A agent logs: ${CONTAINER_NAME}"
-                docker logs "$CONTAINER_ID" 2>&1 | tail -500 || true
-                echo "::endgroup::"
-              done <<< "$LEFTOVER"
-            fi
             echo "Removing leftover A2A agent containers..."
             echo "$LEFTOVER" | xargs -r docker rm -f >/dev/null 2>&1 || true
           fi

--- a/action.yml
+++ b/action.yml
@@ -1258,12 +1258,6 @@ runs:
           echo "Configured A2A agents:"
           infer agents list || true
 
-          # Agent containers run with --rm and are docker-stopped by the CLI at
-          # session end, so their logs are gone before Cleanup can read them.
-          # A background watcher attaches `docker logs -f` to every
-          # inference-agent-* container as it appears (each CLI invocation
-          # starts its own session-suffixed container) and streams to files
-          # that Cleanup dumps after the run.
           if [[ "$DEBUG" == "true" ]] && command -v docker >/dev/null 2>&1; then
             AGENT_LOG_DIR="$RUNNER_TEMP/agent-logs"
             mkdir -p "$AGENT_LOG_DIR"
@@ -1607,10 +1601,6 @@ runs:
         INFER_TOOLS_WRITE_REQUIRE_APPROVAL: "false"
         INFER_TOOLS_EDIT_REQUIRE_APPROVAL: "false"
         INFER_TOOLS_DELETE_REQUIRE_APPROVAL: "false"
-        # WebFetch otherwise falls through to the global tools.safety approval
-        # prompt, which no headless run can answer - it would hard-block the
-        # A2A artifact Download URL fetch. Domain safety still applies via
-        # tools.web_fetch.allowed_domains + the configured-agent-host exemption.
         INFER_TOOLS_WEB_FETCH_REQUIRE_APPROVAL: "false"
         INFER_TOOLS_WEB_FETCH_ALLOWED_DOMAINS: ${{ inputs.web-fetch-domains || 'github.com,raw.githubusercontent.com,api.github.com' }}
         INFER_LOGGING_DEBUG: ${{ inputs.debug }}
@@ -1816,9 +1806,6 @@ runs:
         fi
 
         if [[ -n "$AGENTS_INPUT" ]] && command -v docker >/dev/null 2>&1; then
-          # Agent containers run with --rm, so by now the CLI's docker stop has
-          # usually removed them - dump the log files the setup-agents watcher
-          # streamed while they were alive.
           if [[ "$DEBUG" == "true" ]]; then
             for LOG_FILE in "$RUNNER_TEMP"/agent-logs/*.log; do
               [[ -e "$LOG_FILE" ]] || continue


### PR DESCRIPTION
## Summary

The #266 debug run (30709407379) exposed two blockers this PR fixes:

1. **The agent log dump from #265 never fires on graceful runs.** The CLI starts agent containers with `--rm` (`agent_manager.go`) and `docker stop`s them at session end, so Docker removes them before Cleanup's `docker ps` can see them. On top of that, each CLI invocation starts its own session-suffixed `inference-agent-*` container, so a one-shot log attach at setup would miss the container the run-agent session actually uses. The setup-agents step now starts a debug-gated background watcher that attaches `docker logs -f` to every `inference-agent-*` container as it appears, streaming to `$RUNNER_TEMP/agent-logs/<container>.log`; Cleanup dumps those files (tail -500, one `::group::` per container) instead of querying docker.

2. **WebFetch was unconditionally approval-blocked in action runs** ("not auto-approved and no approver is available"): `tools.web_fetch.require_approval` is unset by default and falls through to the global `tools.safety` approval prompt, which no headless run can answer. This hard-blocks the A2A artifact `Download URL` fetch the CLI instructs the model to perform on task completion — the cli#980 domain exemption never gets a chance. The run-agent step now sets `INFER_TOOLS_WEB_FETCH_REQUIRE_APPROVAL=false` alongside the existing Write/Edit/Delete approvals. Domain safety still applies via `tools.web_fetch.allowed_domains` (the `web-fetch-domains` input) plus the configured-agent-host exemption.

Context: in run 30709407379 the browser-agent completed in ~10 s but published no Download URL and no task `artifacts` — its screenshot tool falls back to a container-local path with only a Debug-level log when artifact creation fails. The captured agent logs are what will pinpoint that upstream failure (and the missing browser-agent trace spans) on the next debug run.

## Changes

- `action.yml` only (Setup A2A agents, run-agent env, Cleanup). No `src/`/`dist/` changes.

## Verification

- `bun run all` green locally (format, eslint, markdownlint, typecheck, 370 tests, package — `dist/` unchanged).
- `bash -n` parse of both edited step scripts passes.
- Observable on the next `debug: true` run with `agents` set: Cleanup shows per-agent log groups with real content, and WebFetch calls are no longer approval-blocked.
