### PR TITLE
ci: sign bump-cli-version commits as the app and default to latest cli release

### DIFF
--- a/.github/workflows/bump-cli-version.yml
+++ b/.github/workflows/bump-cli-version.yml
@@ -5,8 +5,8 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "New CLI version (e.g., v0.157.0)"
-        required: true
+        description: "New CLI version (e.g., v0.157.0). Empty = latest cli release."
+        required: false
         type: string
 
 permissions:
@@ -29,9 +29,21 @@ jobs:
           repositories: |
             ${{ github.event.repository.name }}
 
+      - name: Resolve version
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [ -z "$VERSION" ]; then
+            VERSION=$(gh release view --repo inference-gateway/cli --json tagName -q .tagName)
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
       - name: Update version references
         env:
-          VERSION: ${{ inputs.version }}
+          VERSION: ${{ steps.resolve.outputs.version }}
         run: |
           set -euo pipefail
 
@@ -48,7 +60,7 @@ jobs:
 
       - name: Write PR body
         env:
-          VERSION: ${{ inputs.version }}
+          VERSION: ${{ steps.resolve.outputs.version }}
         run: |
           cat > /tmp/pr-body.md <<PRBODY
           ## Summary
@@ -65,7 +77,7 @@ jobs:
       - name: Compute branch name
         id: branch-name
         env:
-          VERSION: ${{ inputs.version }}
+          VERSION: ${{ steps.resolve.outputs.version }}
         run: |
           BRANCH="bump-cli-version-$(echo "$VERSION" | tr '.' '-')"
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
@@ -74,8 +86,8 @@ jobs:
         uses: peter-evans/create-pull-request@v8.1.1
         with:
           token: ${{ steps.app-token.outputs.token }}
-          commit-message: "chore(deps): bump default CLI version to ${{ inputs.version }}"
-          title: "chore(deps): bump default CLI version to ${{ inputs.version }}"
+          commit-message: "chore(deps): bump default CLI version to ${{ steps.resolve.outputs.version }}"
+          title: "chore(deps): bump default CLI version to ${{ steps.resolve.outputs.version }}"
           body-path: /tmp/pr-body.md
           labels: dependencies
           branch: ${{ steps.branch-name.outputs.branch }}
@@ -83,5 +95,6 @@ jobs:
           add-paths: |
             action.yml
             README.md
+          sign-commits: true
           signoff: true
           delete-branch: true


### PR DESCRIPTION
## Summary

Two fixes to the `Bump CLI Version` dispatch workflow, prompted by PR #271:

- **Verified, bot-attributed commits** — `sign-commits: true` on `peter-evans/create-pull-request`. The commit is now created via the GitHub API with the app token, so it shows as `inference-gateway-maintainer[bot]` with a Verified badge instead of an unsigned commit attributed to the dispatching user.
- **`version` input is now optional** — when left empty, a new `Resolve version` step looks up the latest `inference-gateway/cli` release tag (`gh release view --json tagName`), so the workflow can be dispatched with zero typing. All downstream steps (sed updates, PR body, branch name, commit message, title) read the resolved value.

## Changes

- `.github/workflows/bump-cli-version.yml` only; no `src/`/`dist/` impact.
